### PR TITLE
Use ScreeningEagle mirror for artefacts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,11 +12,11 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "PSPDFKit",
-            url: "https://customers.pspdfkit.com/pspdfkit/xcframework/11.3.0.zip",
+            url: "https://eagleinspect-ios-dependencies.s3.ap-southeast-1.amazonaws.com/swift-package-manager/pspdfkit/xcframework/11.3.0.zip",
             checksum: "486f86a5ff9550c49b42348357f82e148edfa8143e7e3bcbee1c5d40b9746940"),
         .binaryTarget(
             name: "PSPDFKitUI",
-            url: "https://customers.pspdfkit.com/pspdfkitui/xcframework/11.3.0.zip",
+            url: "https://eagleinspect-ios-dependencies.s3.ap-southeast-1.amazonaws.com/swift-package-manager/pspdfkitui/xcframework/11.3.0.zip",
             checksum: "f77ad43f86a7d7eafe519d46207fa36a0038939ec1801731716953bf557e7d77"),
     ]
 )


### PR DESCRIPTION
Sometimes https://customers.pspdfkit.com is not reachable. Hence replacing it with mirror hosted by our own S3.